### PR TITLE
npm package module version conflict; two scripts clauses

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "2.0.5",
   "description": "Complete native binding to the waitpid() syscall",
   "main": "lib/waitpid.js",
-  "scripts": {
-    "install": "node-gyp rebuild"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/joshiggins/node-waitpid2.git"


### PR DESCRIPTION
The npm package is broken, and gives the error 

"Error: The module '/srv/clara/current/hub/node_modules/waitpid2/lib/binding/waitpid.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 48. This version of Node.js requires
NODE_MODULE_VERSION 57. Please try re-compiling or re-installing
"

We can fix this by either going `yarn run install --update-binary` in node_modules/waitpid2, or by installing from source by using `"waitpid2": "git://github.com/joshiggins/node-waitpid2.git#2270e88"` in our package.json

I have no idea why your npm binary is broken.   But having two "scripts" sections in your package.json is an obvious issue and may or may not be related.   I'm not sure which is the right one.